### PR TITLE
Phpstorm pkg flesh out nuspec

### DIFF
--- a/phpstorm/CheckBuildUpdate.ps1
+++ b/phpstorm/CheckBuildUpdate.ps1
@@ -26,6 +26,15 @@ catch {
     }
 }
 
+# Jetbrains can be a little inconsistent in their naming of document pages.
+# So we verify the release specific page actually exist where we think it should.
+$release_url = "https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+$newVersion+Release+Notes"
+$download_release = Invoke-WebRequest -Uri $release_url -UseBasicParsing
+# If not fallback to a documentation page that contains a list of all release note pages.
+if($download_release.RawContent -like '*Page Not Found*') {
+    $release_url = "https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Release+Notes"
+}
+
 # (deprecated) Download Installer and build md5sum
 <#
 if (Test-Path "$directory\phpstorm.exe") { Remove-Item "$directory\phpstorm.exe" }
@@ -44,6 +53,8 @@ Write-Host "Update nuspec"
 $nuspec_template.package.metadata.version = $newVersion
 if (Test-Path "$directory\phpstorm.nuspec") { Remove-Item "$directory\phpstorm.nuspec" }
 $nuspec_template.save("$directory\phpstorm.nuspec")
+Write-Host "Update nuspec <releaseNotes> with new URL"
+(Get-Content "$directory\phpstorm.nuspec") -replace('{{release_url}}', $release_url) | Set-Content "$directory\phpstorm.nuspec"
 
 Write-Host "Update Installer Powershell script with new URL and checksum"
 if (Test-Path "$directory\tools\chocolateyInstall.ps1") { Remove-Item "$directory\tools\chocolateyInstall.ps1" }

--- a/phpstorm/CheckBuildUpdate.ps1
+++ b/phpstorm/CheckBuildUpdate.ps1
@@ -60,10 +60,9 @@ $checksum = ((Invoke-RestMethod -Uri $release.PS.downloads.windows.checksumLink 
 Write-Host "Update nuspec"
 [xml]$nuspec_template = (Get-Content .\phpstorm_template.nuspec)
 $nuspec_template.package.metadata.version = $newVersion
+$nuspec_template.package.metadata.releaseNotes = $release_url
 if (Test-Path "$directory\phpstorm.nuspec") { Remove-Item "$directory\phpstorm.nuspec" }
 $nuspec_template.save("$directory\phpstorm.nuspec")
-Write-Host "Update nuspec <releaseNotes> with new URL"
-(Get-Content "$directory\phpstorm.nuspec") -replace('{{release_url}}', $release_url) | Set-Content "$directory\phpstorm.nuspec"
 
 Write-Host "Update Installer Powershell script with new URL and checksum"
 if (Test-Path "$directory\tools\chocolateyInstall.ps1") { Remove-Item "$directory\tools\chocolateyInstall.ps1" }

--- a/phpstorm/phpstorm_template.nuspec
+++ b/phpstorm/phpstorm_template.nuspec
@@ -3,17 +3,20 @@
     <metadata>
         <id>phpstorm</id>
         <version>{{version}}</version>
+        <packageSourceUrl>https://github.com/mastacheata/chocolatey-packages/tree/master/phpstorm</packageSourceUrl>
         <title>JetBrains PHPStorm</title>
         <authors>JetBrains s.r.o.</authors>
         <owners>mastacheata, Spunkie, Claud, mtolmacs, VeryChocolatey</owners>
         <licenseUrl>https://www.jetbrains.com/phpstorm/buy/</licenseUrl>
         <projectUrl>https://www.jetbrains.com/phpstorm/</projectUrl>
+        <docsUrl>https://www.jetbrains.com/help/phpstorm/</docsUrl>
+        <bugTrackerUrl>https://youtrack.jetbrains.com/issues/WI</bugTrackerUrl>
         <iconUrl>https://raw.githubusercontent.com/mastacheata/chocolatey-packages/master/phpstorm/icon_PhpStorm.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The IDE that actually GETS your code. Supports PHP 5.3, 5.4, 5.5, 5.6 &amp; 7.0 for modern and legacy projects. On the fly error prevention. Best autocompletion &amp; Code Refactoring. Zero configuration debugging. Best JavaScript support included. Frequent updates.</description>
         <summary>PHPStorm - Lightning-smart PHP IDE</summary>
-        <tags>php ide jetbrains</tags>
+        <tags>PHP HTML CSS IDE jetbrains idea PhpStorm EAP PhpStorm-EAP developer productivity code admin</tags>
         <copyright>JetBrains s.r.o.</copyright>
+        <description>The IDE that actually GETS your code. Supports PHP 5.3, 5.4, 5.5, 5.6 &amp; 7.0 for modern and legacy projects. On the fly error prevention. Best autocompletion &amp; Code Refactoring. Zero configuration debugging. Best JavaScript support included. Frequent updates.</description>
     </metadata>
     <files>
         <file src="tools\chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />

--- a/phpstorm/phpstorm_template.nuspec
+++ b/phpstorm/phpstorm_template.nuspec
@@ -17,7 +17,50 @@
         <tags>PHP HTML CSS IDE jetbrains idea PhpStorm EAP PhpStorm-EAP developer productivity code admin</tags>
         <copyright>JetBrains s.r.o.</copyright>
         <releaseNotes>{{release_url}}</releaseNotes>
-        <description>The IDE that actually GETS your code. Supports PHP 5.3, 5.4, 5.5, 5.6 &amp; 7.0 for modern and legacy projects. On the fly error prevention. Best autocompletion &amp; Code Refactoring. Zero configuration debugging. Best JavaScript support included. Frequent updates.</description>
+        <description># PHPStorm
+PhpStorm is built on top of the open-source IntelliJ Platform, which we've been developing and perfecting for over 15 years. Enjoy the fine-tuned, highly customizable experience it provides to fit your development workflow.
+# FEATURES
+## Intelligent coding assistance
+PhpStorm is a PHP IDE that actually 'gets' your code. It supports PHP 5.3/5.4/5.5/5.6/7.0/7.1, provides on-the-fly error prevention, best autocompletion &amp; code refactoring, zero config debugging, and an extended HTML, CSS, and JavaScript editor.
+#### Smart PHP Code Editor
+The IDE provides smart code completion, syntax highlighting, extended code formatting config, on-the-fly error checking, code folding, supports language mixtures and more. Automated refactorings that treat your code with care, helping to make global project settings easily and safely.
+#### Code Quality Analysis
+Hundreds of code inspections verify your code as you type and inspect the whole project for possible errors or code smells. Quick-fixes for most inspections make it easy to fix or improve the code instantly. Alt+Enter shows appropriate options for each inspection.
+#### Easy Code Navigation &amp; Search
+PhpStorm helps you get around your code more efficiently and save time when working with large projects. Jump to a method, function or variable definition in just one click, or search for its usages.
+
+[MORE ABOUT CODING ASSISTANCE](jetbrains.com/phpstorm/features/php_code_editor.html)
+## Debugging, Testing and Profiling
+#### Debugging
+Zero-config debugging makes it really easy to debug your PHP applications. Besides, PhpStorm provides numerous options for debugging your PHP code with Visual Debugger, so you can: inspect variables and user-defined watches, set breakpoints and evaluate an expression in runtime, debug remote applications, debug a page in multiple sessions simultaneously, and more.
+#### Testing
+You can develop PHPUnit tests right in PhpStorm and run them instantly from a directory, file or class, by using the context menu options. Code Coverage from PHPUnit shows how much of your code is covered with tests.
+#### Profiling
+You can profile your applications with Xdebug or Zend Debugger and check aggregated reports in PhpStorm.
+
+[MORE ABOUT DEBUGGING](jetbrains.com/phpstorm/features/debugging_testing_profiling.html)
+## HTML/CSS/JavaScript Editor
+#### HTML &amp; CSS
+All the cutting edge web development technologies are supported including HTML5, CSS, SASS/SCSS, LESS, CoffeeScript, Jade/Pug, etc. Live Edit gives you an opportunity to see all the changes instantly in the browser without refreshing the page.
+#### JavaScript
+The smartest JavaScript Editor is bundled with the IDE, offering code completion, validation and quick fixes, refactorings, JSDoc type annotations support, debugging and unit testing, support for Frameworks, and more.
+#### New Technologies
+PhpStorm provides a streamlined experience for the full development cycle with new languages such as TypeScript, CoffeeScript, and Dart.
+
+[MORE ABOUT HTML/CSS/JAVASCRIPT EDITOR](jetbrains.com/phpstorm/features/html_css_js_editor.html)
+## Development Environment
+#### Databases &amp; SQL
+PhpStorm provides tools and code assistance features for working with databases and SQL in your projects. Connect to databases, edit schemas and table data, run queries, and even analyze schemas with UML diagrams. SQL code can be injected to other languages or edited in SQL Editor, with syntax highlighting, smart code completion, on-the-fly code analysis, code formatting and navigation available.
+#### Other Features
+Perform many routine tasks right from the IDE with support for Vagrant support, Docker, Composer, git, SVN, Mercurial, and more.
+
+[MORE ABOUT DEVELOPMENT ENVIRONMENT](jetbrains.com/phpstorm/features/development_environment.html)
+___
+&gt; #### _Maintainer Notes_
+&gt; _PhpStorm EAP builds are available using the_ **`--prerelease`** _flag_
+&gt; ```
+&gt; choco install phpstorm --prerelease
+&gt; ```</description>
     </metadata>
     <files>
         <file src="tools\chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />

--- a/phpstorm/phpstorm_template.nuspec
+++ b/phpstorm/phpstorm_template.nuspec
@@ -16,6 +16,7 @@
         <summary>PHPStorm - Lightning-smart PHP IDE</summary>
         <tags>PHP HTML CSS IDE jetbrains idea PhpStorm EAP PhpStorm-EAP developer productivity code admin</tags>
         <copyright>JetBrains s.r.o.</copyright>
+        <releaseNotes>{{release_url}}</releaseNotes>
         <description>The IDE that actually GETS your code. Supports PHP 5.3, 5.4, 5.5, 5.6 &amp; 7.0 for modern and legacy projects. On the fly error prevention. Best autocompletion &amp; Code Refactoring. Zero configuration debugging. Best JavaScript support included. Frequent updates.</description>
     </metadata>
     <files>

--- a/phpstorm/phpstorm_template.nuspec
+++ b/phpstorm/phpstorm_template.nuspec
@@ -5,7 +5,7 @@
         <version>{{version}}</version>
         <title>JetBrains PHPStorm</title>
         <authors>JetBrains s.r.o.</authors>
-        <owners>Benedikt Bauer</owners>
+        <owners>mastacheata, Spunkie, Claud, mtolmacs, VeryChocolatey</owners>
         <licenseUrl>https://www.jetbrains.com/phpstorm/buy/</licenseUrl>
         <projectUrl>https://www.jetbrains.com/phpstorm/</projectUrl>
         <iconUrl>https://raw.githubusercontent.com/mastacheata/chocolatey-packages/master/phpstorm/icon_PhpStorm.png</iconUrl>

--- a/phpstorm/phpstorm_template.nuspec
+++ b/phpstorm/phpstorm_template.nuspec
@@ -14,7 +14,7 @@
         <iconUrl>https://raw.githubusercontent.com/mastacheata/chocolatey-packages/master/phpstorm/icon_PhpStorm.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <summary>PHPStorm - Lightning-smart PHP IDE</summary>
-        <tags>PHP HTML CSS IDE jetbrains idea PhpStorm EAP PhpStorm-EAP developer productivity code admin</tags>
+        <tags>PHP HTML CSS IDE jetbrains idea PhpStorm EAP PhpStorm-EAP developer productivity code admin trial</tags>
         <copyright>JetBrains s.r.o.</copyright>
         <releaseNotes>{{release_url}}</releaseNotes>
         <description># PHPStorm


### PR DESCRIPTION
I added a bunch of missing optional fields to nuspec and updated the `<owners>` tag format.

Added `<releaseNotes>` URL to nuspec and updated `CheckBuildUpdate.ps1` to verify and generate the URL. Jetbrains is inconsistent with their naming of release docs so the script verifies we can find the version specific url, if not it falls back to a generic url.

I added a big fancy description to display on the chocolatey.org package listing. It's a markdown version of [this official page](https://www.jetbrains.com/phpstorm/features/) with a bit of the wording changed to fit within the 4000 character description limit and a note added about the EAP version.