### PR TITLE
Fixes to description MD because the MD renderer chocolatey.org uses is junk.

### DIFF
--- a/phpstorm/phpstorm_template.nuspec
+++ b/phpstorm/phpstorm_template.nuspec
@@ -56,11 +56,11 @@ Perform many routine tasks right from the IDE with support for Vagrant support, 
 
 [MORE ABOUT DEVELOPMENT ENVIRONMENT](//jetbrains.com/phpstorm/features/development_environment.html)
 ___
-&gt; #### _Maintainer Notes_
-&gt; _PhpStorm EAP builds are available using the_ **`--prerelease`** _flag_
-&gt; ```
-&gt; choco install phpstorm --prerelease
-&gt; ```</description>
+#### _Maintainer Notes_
+_PhpStorm EAP builds are available using the_ **`--prerelease`** _flag_
+
+    choco install phpstorm --prerelease
+</description>
     </metadata>
     <files>
         <file src="tools\chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />


### PR DESCRIPTION
I noticed you [pushed 2017.1 today](https://chocolatey.org/packages/phpstorm/2017.1) and that there were some issues with the markdown in the pkg description. Here is a quick fix.

Literally every other place that I test my old MD it renders as I expected but not on chocolatey.org. So I had to fallback on some more basic MD syntax.